### PR TITLE
fix #38 aliases for Windows

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,8 @@
 Changelog
 =========
+## TBA
+- Fix #38: broken path aliases on Windows
+
 ## 1.0.2 (04/12/2023)
 - Themes: #34 fix background color in Markdown Editor
 - Themes: #35 fix small color issues (audio player, color, icon and date pickers)

--- a/models/Config.php
+++ b/models/Config.php
@@ -112,9 +112,9 @@ class Config extends \yii\base\Model
         $info['fileName'] = 'theme.css';
 
         if ($this->theme == 'DarkEnterprise') {
-            $info['path'] = '@dark-mode' . DIRECTORY_SEPARATOR . 'resources' . DIRECTORY_SEPARATOR . 'DarkEnterprise' . DIRECTORY_SEPARATOR . 'css';
+            $info['path'] = '@dark-mode/resources/DarkEnterprise/css';
         } elseif ($this->theme == 'DarkHumHub') {
-            $info['path'] = '@dark-mode' . DIRECTORY_SEPARATOR . 'resources' . DIRECTORY_SEPARATOR . 'DarkHumHub' . DIRECTORY_SEPARATOR . 'css';
+            $info['path'] = '@dark-mode/resources/DarkHumHub/css';
         } else {
             // Themes with dark.css
             if (strpos($this->theme, self::DARK_CSS_SUFFIX) !== false) {


### PR DESCRIPTION
Remove DIRECTORY_SEPERATOR from path aliases

They are preserved in the real file paths

fixes #38 