### PR TITLE
Fix update when inactive

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,8 @@
 Changelog
 =========
+## TBA
+- Fix #49: module update with error logged when module is inactive
+
 ## 1.0.5 (23/1/2024)
 - Fix #47: wrong message category of save button
 

--- a/models/Config.php
+++ b/models/Config.php
@@ -16,7 +16,7 @@ class Config extends \yii\base\Model
 
     public $theme;
 
-    public $showButton;
+    public $showButton = true;
 
     public function init()
     {
@@ -25,11 +25,8 @@ class Config extends \yii\base\Model
         $module = Yii::$app->getModule('dark-mode');
         // make sure module is enabled before retrieving settings, see https://github.com/felixhahnweilheim/humhub-dark-mode/issues/48
         if ($module) {
-            $settings = Yii::$app->getModule('dark-mode')->settings;
-
-            $this->theme = $settings->get('theme');
-
-            $this->showButton = $settings->get('showButton', true);
+            $this->theme = $module->settings->get('theme');
+            $this->showButton = $module->settings->get('showButton', $this->showButton);
         }
 
         // If no setting was found, get recommended theme or fallback (DarkHumHub) 

--- a/models/Config.php
+++ b/models/Config.php
@@ -16,7 +16,7 @@ class Config extends \yii\base\Model
 
     public $theme;
 
-    public $showButton = true;
+    public $showButton;
 
     public function init()
     {

--- a/models/Config.php
+++ b/models/Config.php
@@ -16,17 +16,21 @@ class Config extends \yii\base\Model
 
     public $theme;
 
-    public $showButton;
+    public $showButton = true;
 
     public function init()
     {
         parent::init();
 
-        $settings = Yii::$app->getModule('dark-mode')->settings;
+        $module = Yii::$app->getModule('dark-mode');
+        // make sure module is enabled before retrieving settings, see https://github.com/felixhahnweilheim/humhub-dark-mode/issues/48
+        if ($module) {
+            $settings = Yii::$app->getModule('dark-mode')->settings;
 
-        $this->theme = $settings->get('theme');
+            $this->theme = $settings->get('theme');
 
-        $this->showButton = $settings->get('showButton', true);
+            $this->showButton = $settings->get('showButton', true);
+        }
 
         // If no setting was found, get recommended theme or fallback (DarkHumHub) 
         if (empty($this->theme)) {


### PR DESCRIPTION
fixes the minor bug mentioned in https://github.com/felixhahnweilheim/humhub-dark-mode/issues/48
When the module was updated when it was not active, an error was logged.

(The ModuleService tries to publish the assets in https://github.com/humhub/humhub/blob/master/protected/humhub/modules/marketplace/services/ModuleService.php#L104 That was not possible when the module was inactive because the module instance returned null, so the settings could not be retrieved.)