### PR TITLE
Switch style by JS

### DIFF
--- a/assets/DarkStyleAsset.php
+++ b/assets/DarkStyleAsset.php
@@ -24,7 +24,7 @@ class DarkStyleAsset extends AssetBundle
     const FILENAME_CACHE = "darkMode_fileName";
     
     // Tell browser to use stylesheet only when in dark mode
-    public $cssOptions = ['media' => 'screen and (prefers-color-scheme: dark)'];
+    public $cssOptions = ['id' => 'dark-css-link', 'media' => 'screen and (prefers-color-scheme: dark)'];
 
     public function init()
     {

--- a/assets/ForceDarkStyleAsset.php
+++ b/assets/ForceDarkStyleAsset.php
@@ -10,5 +10,5 @@ use humhub\modules\darkMode\assets\DarkStyleAsset;
  */
 class ForceDarkStyleAsset extends DarkStyleAsset
 {
-    public $cssOptions = ['media' => 'screen'];
+    public $cssOptions = ['id' => 'dark-css-link', 'media' => 'screen'];
 }

--- a/assets/SettingsAsset.php
+++ b/assets/SettingsAsset.php
@@ -30,8 +30,6 @@ class SettingsAsset extends AssetBundle
             'css-url' => $url
         ]);
         
-        Yii::error(Url::to(['/dark-mode/user/modal']));
         return parent::register($view);
     }
-    
 }

--- a/assets/SettingsAsset.php
+++ b/assets/SettingsAsset.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace humhub\modules\darkMode\assets;
+
+use humhub\components\assets\AssetBundle;
+use yii\helpers\Url;
+use Yii;
+
+class SettingsAsset extends AssetBundle
+{
+    public $publishOptions = [
+        'forceCopy' => true//todo
+    ];
+    
+    public $sourcePath = '@dark-mode/resources/module';
+    
+    public $js = [
+        'js/humhub.dark-mode.switch.js'
+    ];
+    
+    public static function register($view)
+    {
+        $darkStyleAsset = new DarkStyleAsset();
+        $am = $view->getAssetManager();
+        $url = $am->publish($darkStyleAsset->sourcePath . $am->getAssetPath($darkStyleAsset, $darkStyleAsset->css[0]))[1];
+        $view->registerJsConfig('dark-mode.switch', [
+            'initOnAjaxUrls' => [
+                Url::to(['/dark-mode/user/modal']), // Don't add any params to the URL
+            ],
+            'css-url' => $url
+        ]);
+        
+        Yii::error(Url::to(['/dark-mode/user/modal']));
+        return parent::register($view);
+    }
+    
+}

--- a/assets/SettingsAsset.php
+++ b/assets/SettingsAsset.php
@@ -8,10 +8,6 @@ use Yii;
 
 class SettingsAsset extends AssetBundle
 {
-    public $publishOptions = [
-        'forceCopy' => true//todo
-    ];
-    
     public $sourcePath = '@dark-mode/resources/module';
     
     public $js = [

--- a/controllers/UserController.php
+++ b/controllers/UserController.php
@@ -37,8 +37,7 @@ class UserController extends \humhub\components\Controller
         if ($form->load(Yii::$app->request->post()) && $form->save()) {
 
             // Close modal and reload page to make apply asset changes (this way the "Saved" message is not shown)
-            return ModalClose::widget(['saved' => true]) .
-                ' <script ' . \humhub\libs\Html::nonce() . '>$(function () { location.reload() }); </script>';
+            return ModalClose::widget(['saved' => true]);
         }
 
         return $this->renderAjax('modal', ['model' => $form]);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 Changelog
 =========
 ## 1.0.9 TBA
+- Enh: update theme while clicking (removes the full page reload)
 - Update URL to documentation
 
 ## 1.0.8 (19/06/2024)

--- a/resources/module/js/humhub.dark-mode.switch.js
+++ b/resources/module/js/humhub.dark-mode.switch.js
@@ -1,0 +1,68 @@
+humhub.module('dark-mode.switch', function (module, require, $) {
+    module.initOnPjaxLoad = true;
+    module.initOnAjaxLoad = true;
+    
+    let $inputRadio;
+    let $cancelBtn;
+    let $startVal;
+    const $cssUrl = module.config['css-url'];
+    
+    const init = function () {
+        $(function () {
+            initializeInputs();
+            bindInputEvents();
+        });
+    };
+    
+    function initializeInputs() {
+        $inputRadio = $('#usersetting-darkmode');
+        $cancelBtn = $('button[data-modal-close]');
+        $startVal = $('input[name="UserSetting[darkMode]"]:checked').val();
+    }
+    
+    function bindInputEvents() {
+        $inputRadio.on('input', updateMode);
+        $cancelBtn.on('click', cancelChanges);
+    }
+    
+    function updateMode() {
+        var val = $('input[name="UserSetting[darkMode]"]:checked').val();
+        setMode(val);
+    }
+    
+    function cancelChanges() {
+        setMode($startVal);
+    }
+    
+    function setMode(val) {
+        if      (val == 'default') setDefault();
+        else if (val == 'light')   setLight();
+        else if (val == 'dark')    setDark();
+    }
+    
+    function setDefault() {
+        if ($('#dark-css-link').length) {
+            $('#dark-css-link').attr('media', 'screen and (prefers-color-scheme: dark)');
+        } else {
+            $('head').append('<link id="dark-css-link" rel="stylesheet" type="text/css" media="screen and (prefers-color-scheme: dark)" href="' + $cssUrl + '">');
+        }
+    }
+    
+    function setLight() {
+        if ($('#dark-css-link').length) {
+            $('#dark-css-link').remove();
+        }
+    }
+    
+   function setDark() {
+        if ($('#dark-css-link').length) {
+            $('#dark-css-link').attr('media', 'screen');
+        } else {
+            $('head').append('<link id="dark-css-link" rel="stylesheet" type="text/css" media="screen" href="' + $cssUrl + '">');
+        }
+    }
+
+    module.export({
+        init: init
+    });
+});

--- a/views/user/form.php
+++ b/views/user/form.php
@@ -1,4 +1,5 @@
 <?php
+\humhub\modules\darkMode\assets\SettingsAsset::register($this);
 ?>
 <?= $form->field($model, 'darkMode')->radioList($model->getOptions()); ?>
 <?= Yii::t('DarkModeModule.base', 'Choose "Follow system" to automatically switch between light and dark mode according to your browser or system preferences.') ?>


### PR DESCRIPTION
solves https://github.com/felixhahnweilheim/humhub-dark-mode/issues/33

Everything solved by JS. The full page reload is removed:
- Theme switches when you click a new value.
- When you save, the current state stays.
- When you cancel the original state is recovered.

## To do
- [x] update changelog